### PR TITLE
FIx in case of RateRequest::getAllItems returning null instead of an …

### DIFF
--- a/Model/Wrapper/Quote.php
+++ b/Model/Wrapper/Quote.php
@@ -16,9 +16,12 @@ class Quote extends SourceWrapper
         $requestWrapper = $this->registry->get('request');
         if (isset($requestWrapper) && $requestWrapper->getSource() instanceof \Magento\Quote\Model\Quote\Address\RateRequest) {
             $request = $requestWrapper->getSource();
-            foreach ($request->getAllItems() as $item) {
-                if ($quote = $item->getQuote()) {
-                    return $quote;
+            $requestItems = $request->getAllItems();
+            if ($requestItems) {
+                foreach ($requestItems as $item) {
+                    if ($quote = $item->getQuote()) {
+                        return $quote;
+                    }
                 }
             }
         }


### PR DESCRIPTION
…array

We had case in our code of method `RateRequest::getAllItems()` returning null.
So I added this quick test in order to avoid further exception like this one `Warning: Invalid argument supplied for foreach() in /var/www/html/vendor/owebia/magento2-module-advanced-setting-core/Model/Wrapper/Quote.php on line 19`